### PR TITLE
Bump github/codeql-action from 3.23.2 to 3.24.0

### DIFF
--- a/.github/workflows/scorecards-analysis.yaml
+++ b/.github/workflows/scorecards-analysis.yaml
@@ -70,6 +70,6 @@ jobs:
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@b7bf0a3ed3ecfa44160715d7c442788f65f0f923    # 2.1.22
+        uses: github/codeql-action/upload-sarif@e8893c57a1f3a2b659b6b55564fdfdbbd2982911    # 2.1.22
         with:
           sarif_file: results.sarif

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -63,7 +63,7 @@
     <activemq.version>6.0.1</activemq.version>
     <angus-activation.version>2.0.1</angus-activation.version>
     <angus-mail.version>2.0.2</angus-mail.version>
-    <assertj.version>3.25.2</assertj.version>
+    <assertj.version>3.25.3</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <bsh.version>2.0b6</bsh.version>
     <cassandra.version>3.11.16</cassandra.version>

--- a/src/changelog/.2.x.x/update_github_codeql_action.xml
+++ b/src/changelog/.2.x.x/update_github_codeql_action.xml
@@ -3,6 +3,6 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
        type="updated">
-  <issue id="2253" link="https://github.com/apache/logging-log4j2/pull/2253"/>
-  <description format="asciidoc">Update `github/codeql-action` to version `3.23.2`</description>
+  <issue id="2264" link="https://github.com/apache/logging-log4j2/pull/2264"/>
+  <description format="asciidoc">Update `github/codeql-action` to version `3.24.0`</description>
 </entry>

--- a/src/changelog/.2.x.x/update_org_assertj_assertj_core.xml
+++ b/src/changelog/.2.x.x/update_org_assertj_assertj_core.xml
@@ -3,6 +3,6 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
        type="updated">
-  <issue id="2244" link="https://github.com/apache/logging-log4j2/pull/2244"/>
-  <description format="asciidoc">Update `org.assertj:assertj-core` to version `3.25.2`</description>
+  <issue id="2262" link="https://github.com/apache/logging-log4j2/pull/2262"/>
+  <description format="asciidoc">Update `org.assertj:assertj-core` to version `3.25.3`</description>
 </entry>

--- a/src/site/_release-notes/_2.x.x.adoc
+++ b/src/site/_release-notes/_2.x.x.adoc
@@ -50,7 +50,7 @@ This releases contains ...
 * Update `co.elastic.clients:elasticsearch-java` to version `8.12.0` (https://github.com/apache/logging-log4j2/pull/2212[2212])
 * Update `com.fasterxml.jackson:jackson-bom` to version `2.16.1` (https://github.com/apache/logging-log4j2/pull/2126[2126])
 * Update `com.google.code.java-allocation-instrumenter:java-allocation-instrumenter` to version `3.3.4` (https://github.com/apache/logging-log4j2/pull/2103[2103])
-* Update `github/codeql-action` to version `3.23.2` (https://github.com/apache/logging-log4j2/pull/2253[2253])
+* Update `github/codeql-action` to version `3.24.0` (https://github.com/apache/logging-log4j2/pull/2264[2264])
 * Update `io.netty:netty-bom` to version `4.1.106.Final` (https://github.com/apache/logging-log4j2/pull/2225[2225])
 * Update `org.apache.logging:logging-parent` to version `10.6.0` (https://github.com/apache/logging-log4j2/pull/2197[2197])
 * Update `org.apache.maven.surefire:surefire-junit47` to version `3.2.5` (https://github.com/apache/logging-log4j2/pull/2178[2178])

--- a/src/site/_release-notes/_2.x.x.adoc
+++ b/src/site/_release-notes/_2.x.x.adoc
@@ -54,5 +54,5 @@ This releases contains ...
 * Update `io.netty:netty-bom` to version `4.1.106.Final` (https://github.com/apache/logging-log4j2/pull/2225[2225])
 * Update `org.apache.logging:logging-parent` to version `10.6.0` (https://github.com/apache/logging-log4j2/pull/2197[2197])
 * Update `org.apache.maven.surefire:surefire-junit47` to version `3.2.5` (https://github.com/apache/logging-log4j2/pull/2178[2178])
-* Update `org.assertj:assertj-core` to version `3.25.2` (https://github.com/apache/logging-log4j2/pull/2244[2244])
+* Update `org.assertj:assertj-core` to version `3.25.3` (https://github.com/apache/logging-log4j2/pull/2262[2262])
 * Update `org.codehaus.groovy:groovy-bom` to version `3.0.20` (https://github.com/apache/logging-log4j2/pull/2125[2125])


### PR DESCRIPTION
pr_rerun dependabot/github_actions/2.x/github/codeql-action-3.24.0 to 2.x