### PR TITLE
Bump log4j-api.version from 2.24.0-SNAPSHOT to 3.0.0-beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
     <project.build.outputTimestamp>2024-02-17T17:58:36Z</project.build.outputTimestamp>
 
     <!-- Version of Log4j API required -->
-    <log4j-api.version>2.24.0-SNAPSHOT</log4j-api.version>
+    <log4j-api.version>3.0.0-beta2</log4j-api.version>
 
     <!-- ========================
          Site-specific properties


### PR DESCRIPTION
pr_rerun dependabot/maven/main/log4j-api.version-3.0.0-beta2 to main