### PR TITLE
Bump org.springframework.cloud:spring-cloud-dependencies from 2021.0.8 to 2021.0.9

### DIFF
--- a/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config-client/pom.xml
@@ -45,7 +45,7 @@
     <Fragment-Host>org.apache.logging.log4j.core</Fragment-Host>
 
     <!-- dependency versions -->
-    <spring-cloud.version>2021.0.8</spring-cloud.version>
+    <spring-cloud.version>2021.0.9</spring-cloud.version>
 
   </properties>
 


### PR DESCRIPTION
pr_rerun dependabot/maven/2.x/org.springframework.cloud-spring-cloud-dependencies-2021.0.9 to 2.x