### PR TITLE
Bump org.eclipse.platform:org.eclipse.osgi from 3.18.400 to 3.18.600

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -142,7 +142,7 @@
     <nashorn.version>15.4</nashorn.version>
     <netty.version>4.1.101.Final</netty.version>
     <opentest4j.version>1.3.0</opentest4j.version>
-    <org.eclipse.osgi.version>3.18.400</org.eclipse.osgi.version>
+    <org.eclipse.osgi.version>3.18.600</org.eclipse.osgi.version>
     <oro.version>2.0.8</oro.version>
     <!-- The OSGi API version MUST always be the MINIMUM version Log4j supports -->
     <osgi.framework.version>1.10.0</osgi.framework.version>


### PR DESCRIPTION
pr_rerun dependabot/maven/main/org.eclipse.platform-org.eclipse.osgi-3.18.600 to main