### PR TITLE
[Issue2281]  The core.Logger#setLevel method should work like Configurator#setLevel()

### DIFF
--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/CoreLogger.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/CoreLogger.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.jul;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 /**
  * Log4j Core implementation of the JUL {@link Logger} class. <strong>Note that this implementation does
@@ -44,7 +45,7 @@ public class CoreLogger extends ApiLogger {
     @Override
     public void setLevel(final Level level) throws SecurityException {
         super.doSetLevel(level); // checks permissions
-        logger.setLevel(LevelTranslator.toLevel(level));
+        Configurator.setLevel(logger, LevelTranslator.toLevel(level));
     }
 
     /**

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CoreLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CoreLoggerTest.java
@@ -18,8 +18,10 @@ package org.apache.logging.log4j.jul.test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -46,6 +48,7 @@ public class CoreLoggerTest extends AbstractLoggerTest {
 
     @Before
     public void setUp() throws Exception {
+        LogManager.getLogManager().reset();
         logger = Logger.getLogger(LOGGER_NAME);
         logger.setFilter(null);
         assertThat(logger.getLevel(), equalTo(Level.FINE));
@@ -98,6 +101,35 @@ public class CoreLoggerTest extends AbstractLoggerTest {
         assertThat(logger.getLevel(), equalTo(Level.FINE));
         assertThat(childLogger.getLevel(), equalTo(Level.FINE));
         assertThat(childLogger.isLoggable(Level.ALL), is(false));
+    }
+
+    @Test
+    public void testSetLevelIssue2281() {
+        final Logger a = Logger.getLogger("a");
+        final Logger a_b = Logger.getLogger("a.b");
+        final Logger a_b_c = Logger.getLogger("a.b.c");
+        // test default for this test
+        assertEquals(Level.INFO, a.getLevel());
+        assertEquals(Level.INFO, a_b.getLevel());
+        assertEquals(Level.INFO, a_b_c.getLevel());
+        // all levels
+        for (final Level level : new Level[] {
+            Level.ALL,
+            Level.CONFIG,
+            Level.FINE,
+            Level.FINER,
+            Level.FINEST,
+            Level.INFO,
+            Level.OFF,
+            Level.SEVERE,
+            Level.WARNING
+        }) {
+            a.setLevel(level);
+            assertEquals(level, a.getLevel());
+            assertTrue(a.isLoggable(level));
+            assertTrue(a_b.isLoggable(level));
+            assertTrue(a_b_c.isLoggable(level));
+        }
     }
 
     @Test

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CoreLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CoreLoggerTest.java
@@ -113,22 +113,25 @@ public class CoreLoggerTest extends AbstractLoggerTest {
         assertEquals(Level.INFO, a_b.getLevel());
         assertEquals(Level.INFO, a_b_c.getLevel());
         // all levels
-        for (final Level level : new Level[] {
-            Level.ALL,
+        final Level[] levels = new Level[] {
+            Level.OFF,
+            Level.SEVERE,
+            Level.WARNING,
+            Level.INFO,
             Level.CONFIG,
             Level.FINE,
             Level.FINER,
             Level.FINEST,
-            Level.INFO,
-            Level.OFF,
-            Level.SEVERE,
-            Level.WARNING
-        }) {
+            Level.ALL
+        };
+        for (int i = 0; i < levels.length - 1; i++) {
+            final Level level = levels[i];
+            final Level nextLevel = levels[i + 1];
             a.setLevel(level);
             assertEquals(level, a.getLevel());
-            assertTrue(a.isLoggable(level));
-            assertTrue(a_b.isLoggable(level));
-            assertTrue(a_b_c.isLoggable(level));
+            assertTrue(a.isLoggable(level) && !a.isLoggable(nextLevel));
+            assertTrue(a_b.isLoggable(level) && !a.isLoggable(nextLevel));
+            assertTrue(a_b_c.isLoggable(level) && !a.isLoggable(nextLevel));
         }
     }
 

--- a/src/changelog/.2.x.x/2282_fix_jul_set_level.xml
+++ b/src/changelog/.2.x.x/2282_fix_jul_set_level.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="2282" link="https://github.com/apache/logging-log4j2/issues/2282"/>
+  <description format="asciidoc">
+    Fix the behavior of `CoreLogger#setLevel` in the log4j-jul module.
+  </description>
+</entry>


### PR DESCRIPTION
pr_rerun 2.x-jul-issue-2281 to 2.x