### PR TITLE
Bump org.apache.logging:logging-parent from 10.5.0 to 10.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.logging</groupId>
     <artifactId>logging-parent</artifactId>
-    <version>10.5.0</version>
+    <version>10.6.0</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
pr_rerun dependabot/maven/2.x/org.apache.logging-logging-parent-10.6.0 to 2.x