### PR TITLE
Bump org.apache.maven.surefire:surefire-junit47 from 3.1.2 to 3.2.2

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -90,7 +90,7 @@
     <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
     <exam-maven-plugin.version>4.13.5</exam-maven-plugin.version>
     <!-- `surefire.version` property used in `apache.org:apache`: -->
-    <surefire.version>3.1.2</surefire.version>
+    <surefire.version>3.2.2</surefire.version>
 
     <!-- =====================================================
          Direct dependency version properties (in alphabetical order)


### PR DESCRIPTION
pr_rerun dependabot/maven/main/org.apache.maven.surefire-surefire-junit47-3.2.2 to main