### PR TITLE
Bump actions/upload-artifact from 3.1.3 to 4.0.0

### DIFF
--- a/.github/workflows/scorecards-analysis.yaml
+++ b/.github/workflows/scorecards-analysis.yaml
@@ -59,7 +59,7 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32    # 3.1.0
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392    # 3.1.0
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
pr_rerun dependabot/github_actions/2.x/actions/upload-artifact-4.0.0 to 2.x