### PR TITLE
Bump com.fasterxml.woodstox:woodstox-core from 6.5.1 to 6.6.0

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -144,7 +144,7 @@
     <tomcat-juli.version>10.0.27</tomcat-juli.version>
     <velocity.version>1.7</velocity.version>
     <wiremock.version>2.35.1</wiremock.version>
-    <woodstox.version>6.5.1</woodstox.version>
+    <woodstox.version>6.6.0</woodstox.version>
     <xmlunit.version>2.9.1</xmlunit.version>
     <xz.version>1.9</xz.version>
     <zstd.version>1.5.5-11</zstd.version>


### PR DESCRIPTION
pr_rerun dependabot/maven/2.x/com.fasterxml.woodstox-woodstox-core-6.6.0 to 2.x