### PR TITLE
Bump org.elasticsearch.client:elasticsearch-rest-high-level-client from 7.17.19 to 7.17.20

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -105,7 +105,7 @@
     <commons-logging.version>1.3.1</commons-logging.version>
     <conversant.disruptor.version>1.2.21</conversant.disruptor.version>
     <disruptor.version>4.0.0</disruptor.version>
-    <elasticsearch.version>7.17.19</elasticsearch.version>
+    <elasticsearch.version>7.17.20</elasticsearch.version>
     <embedded-ldap.version>0.9.0</embedded-ldap.version>
     <felix.version>7.0.5</felix.version>
     <flapdoodle-embed.version>4.8.1</flapdoodle-embed.version>

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -112,7 +112,7 @@
     <flapdoodle-reverse.version>1.7.2</flapdoodle-reverse.version>
     <flume.version>1.11.0</flume.version>
     <graalvm.version>24.0.0</graalvm.version>
-    <groovy.version>4.0.20</groovy.version>
+    <groovy.version>4.0.21</groovy.version>
     <guava.version>33.1.0-jre</guava.version>
     <h2.version>2.2.222</h2.version>
     <hadoop.version>1.2.1</hadoop.version>

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -100,7 +100,7 @@
     <commons-compress.version>1.26.1</commons-compress.version>
     <commons-csv.version>1.10.0</commons-csv.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
-    <commons-io.version>2.16.0</commons-io.version>
+    <commons-io.version>2.16.1</commons-io.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <commons-logging.version>1.3.1</commons-logging.version>
     <conversant.disruptor.version>1.2.21</conversant.disruptor.version>

--- a/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config-client/pom.xml
@@ -36,7 +36,7 @@
     <!-- Dependency version -->
     <spring-boot.version>3.2.4</spring-boot.version>
     <spring-cloud.version>4.1.2</spring-cloud.version>
-    <spring-framework.version>6.1.5</spring-framework.version>
+    <spring-framework.version>6.1.6</spring-framework.version>
 
     <!--
       ~ OSGi and JPMS options

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
       <roles>
         <role>Committer</role>
       </roles>
-      <timezone>Asia/Kolkata</timezone>
+      <timezone>America/New York</timezone>
     </developer>
 
     <developer>

--- a/src/changelog/.3.x.x/update_commons_io_commons_io.xml
+++ b/src/changelog/.3.x.x/update_commons_io_commons_io.xml
@@ -3,6 +3,6 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
        type="updated">
-  <issue id="2429" link="https://github.com/apache/logging-log4j2/pull/2429"/>
-  <description format="asciidoc">Update `commons-io:commons-io` to version `2.16.0`</description>
+  <issue id="2456" link="https://github.com/apache/logging-log4j2/pull/2456"/>
+  <description format="asciidoc">Update `commons-io:commons-io` to version `2.16.1`</description>
 </entry>

--- a/src/changelog/.3.x.x/update_org_apache_groovy_groovy_bom.xml
+++ b/src/changelog/.3.x.x/update_org_apache_groovy_groovy_bom.xml
@@ -3,6 +3,6 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
        type="updated">
-  <issue id="2376" link="https://github.com/apache/logging-log4j2/pull/2376"/>
-  <description format="asciidoc">Update `org.apache.groovy:groovy-bom` to version `4.0.20`</description>
+  <issue id="2457" link="https://github.com/apache/logging-log4j2/pull/2457"/>
+  <description format="asciidoc">Update `org.apache.groovy:groovy-bom` to version `4.0.21`</description>
 </entry>

--- a/src/changelog/.3.x.x/update_org_elasticsearch_client_elasticsearch_rest_high_level_client.xml
+++ b/src/changelog/.3.x.x/update_org_elasticsearch_client_elasticsearch_rest_high_level_client.xml
@@ -3,6 +3,6 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
        type="updated">
-  <issue id="2418" link="https://github.com/apache/logging-log4j2/pull/2418"/>
-  <description format="asciidoc">Update `org.elasticsearch.client:elasticsearch-rest-high-level-client` to version `7.17.19`</description>
+  <issue id="2455" link="https://github.com/apache/logging-log4j2/pull/2455"/>
+  <description format="asciidoc">Update `org.elasticsearch.client:elasticsearch-rest-high-level-client` to version `7.17.20`</description>
 </entry>

--- a/src/changelog/.3.x.x/update_org_springframework_spring_framework_bom.xml
+++ b/src/changelog/.3.x.x/update_org_springframework_spring_framework_bom.xml
@@ -3,6 +3,6 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
        type="updated">
-  <issue id="2382" link="https://github.com/apache/logging-log4j2/pull/2382"/>
-  <description format="asciidoc">Update `org.springframework:spring-framework-bom` to version `6.1.5`</description>
+  <issue id="2465" link="https://github.com/apache/logging-log4j2/pull/2465"/>
+  <description format="asciidoc">Update `org.springframework:spring-framework-bom` to version `6.1.6`</description>
 </entry>


### PR DESCRIPTION
pr_rerun dependabot/maven/main/org.elasticsearch.client-elasticsearch-rest-high-level-client-7.17.20 to main