### PR TITLE
Fix issue #2380: Log messages with insufficient parameters should not throw exception.

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,15 +67,12 @@ class ParameterFormatterTest {
         }
     }
 
-    @ParameterizedTest
-    @CsvSource({"1,foo {}", "2,bar {}{}"})
-    void format_should_fail_on_insufficient_args(final int placeholderCount, final String pattern) {
-        final int argCount = placeholderCount - 1;
-        assertThatThrownBy(() -> ParameterFormatter.format(pattern, new Object[argCount], argCount))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "found %d argument placeholders, but provided %d for pattern `%s`",
-                        placeholderCount, argCount, pattern);
+    @Test
+    void formatWithInsufficientArgs() {
+        final String pattern = "Test message {}-{} {}";
+        final Object[] args = {"a", "b"};
+        final String message = ParameterFormatter.format(pattern, args, args.length);
+        assertThat(message).isEqualTo("Test message a-b {}");
     }
 
     @ParameterizedTest

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
@@ -78,10 +78,10 @@ class ParameterFormatterTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"2,pan {} {},a,pan a {}", "3,pan {}{}{},a-b,pan ab{}", "1,pan {},a-b-c,pan a"})
-    void format_should_fail_on_insufficient_args(
+    @CsvSource({"2,pan {} {},a,pan a {}", "3,pan {}{}{},a b,pan ab{}", "1,pan {},a b c,pan a"})
+    void format_should_warn_on_insufficient_args(
             final int placeholderCount, final String pattern, final String argsStr, final String expectedMessage) {
-        final String[] args = argsStr.split("-");
+        final String[] args = argsStr.split(" ");
         final int argCount = args.length;
 
         String actualMessage = ParameterFormatter.format(pattern, args, argCount);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -244,14 +244,17 @@ final class ParameterFormatter {
             return;
         }
 
-        // check if there are insufficient arguments that do not include Throwable arg
-        final int realArgCount = args.length;
-        final int noThrowableArgCount = realArgCount - ((args[realArgCount - 1] instanceof Throwable) ? 1 : 0);
-        if (analysis.placeholderCount != noThrowableArgCount) {
-            final String message = String.format(
-                    "found %d argument placeholders, but provided %d for pattern `%s`",
-                    analysis.placeholderCount, realArgCount, pattern);
-            STATUS_LOGGER.warn(message);
+        // #2380: check if the count of placeholder is not equal to the count of arguments
+        if (analysis.placeholderCount != argCount) {
+            final int realArgCount = args.length;
+            final int noThrowableArgCount = realArgCount - ((args[realArgCount - 1] instanceof Throwable) ? 1 : 0);
+            if (analysis.placeholderCount != noThrowableArgCount) {
+                STATUS_LOGGER.warn(
+                        "found {} argument placeholders, but provided {} for pattern `{}`",
+                        analysis.placeholderCount,
+                        Math.min(realArgCount, argCount),
+                        pattern);
+            }
         }
 
         // Fast-path for patterns containing no escapes

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -246,13 +246,13 @@ final class ParameterFormatter {
 
         // #2380: check if the count of placeholder is not equal to the count of arguments
         if (analysis.placeholderCount != argCount) {
-            final int realArgCount = args.length;
-            final int noThrowableArgCount = realArgCount - ((args[realArgCount - 1] instanceof Throwable) ? 1 : 0);
+            final int noThrowableArgCount =
+                    argCount < 1 ? 0 : argCount - ((args[argCount - 1] instanceof Throwable) ? 1 : 0);
             if (analysis.placeholderCount != noThrowableArgCount) {
                 STATUS_LOGGER.warn(
                         "found {} argument placeholders, but provided {} for pattern `{}`",
                         analysis.placeholderCount,
-                        Math.min(realArgCount, argCount),
+                        argCount,
                         pattern);
             }
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -239,17 +239,18 @@ final class ParameterFormatter {
             final MessagePatternAnalysis analysis) {
 
         // Short-circuit if there is nothing interesting
-        if (pattern == null || args == null || args.length == 0 || analysis.placeholderCount == 0) {
+        if (pattern == null || args == null || analysis.placeholderCount == 0) {
             buffer.append(pattern);
             return;
         }
 
         // check if there are insufficient arguments that do not include Throwable arg
-        final int noThrowableArgCount = argCount - ((args[argCount - 1] instanceof Throwable) ? 1 : 0);
+        final int realArgCount = args.length;
+        final int noThrowableArgCount = realArgCount - ((args[realArgCount - 1] instanceof Throwable) ? 1 : 0);
         if (analysis.placeholderCount != noThrowableArgCount) {
             final String message = String.format(
                     "found %d argument placeholders, but provided %d for pattern `%s`",
-                    analysis.placeholderCount, args.length, pattern);
+                    analysis.placeholderCount, realArgCount, pattern);
             STATUS_LOGGER.warn(message);
         }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -240,14 +240,6 @@ final class ParameterFormatter {
             return;
         }
 
-        // Fail if there are insufficient arguments
-        if (analysis.placeholderCount > args.length) {
-            final String message = String.format(
-                    "found %d argument placeholders, but provided %d for pattern `%s`",
-                    analysis.placeholderCount, args.length, pattern);
-            throw new IllegalArgumentException(message);
-        }
-
         // Fast-path for patterns containing no escapes
         if (analysis.escapedCharFound) {
             formatMessageContainingEscapes(buffer, pattern, args, argCount, analysis);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -26,9 +26,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterFormatter.MessagePatternAnalysis;
-import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.internal.SerializationUtil;
@@ -80,8 +78,6 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     public static final String ERROR_SUFFIX = ParameterFormatter.ERROR_SUFFIX;
 
     private static final long serialVersionUID = -665975803997290697L;
-
-    private static final Logger STATUS_LOGGER = StatusLogger.getLogger();
 
     private static final ThreadLocal<FormatBufferHolder> FORMAT_BUFFER_HOLDER_REF =
             Constants.ENABLE_THREADLOCALS ? ThreadLocal.withInitial(FormatBufferHolder::new) : null;
@@ -278,12 +274,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
             buffer.append(formattedMessage);
         } else {
             final int argCount = args != null ? args.length : 0;
-            try {
-                ParameterFormatter.formatMessage(buffer, pattern, args, argCount, patternAnalysis);
-            } catch (final Exception error) {
-                STATUS_LOGGER.error("Unable to format msg: {}", pattern, error);
-                buffer.append(pattern);
-            }
+            ParameterFormatter.formatMessage(buffer, pattern, args, argCount, patternAnalysis);
         }
     }
 
@@ -294,12 +285,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      */
     public static String format(final String pattern, final Object[] args) {
         final int argCount = args != null ? args.length : 0;
-        try {
-            return ParameterFormatter.format(pattern, args, argCount);
-        } catch (final Exception error) {
-            STATUS_LOGGER.error("Unable to format msg: {}", pattern, error);
-            return pattern;
-        }
+        return ParameterFormatter.format(pattern, args, argCount);
     }
 
     @Override

--- a/src/changelog/.2.x.x/fix_2380_insufficient_args_in_ParameterFormatter.xml
+++ b/src/changelog/.2.x.x/fix_2380_insufficient_args_in_ParameterFormatter.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <issue id="2380" link="https://github.com/apache/logging-log4j2/pull/2380"/>
+  <description format="asciidoc">
+    Fix that parameterized message formatting throws an exception when there are insufficient number of parameters.
+    It previously simply didn't replace the '{}' sequence. The behavior changed in 2.21.0 and should be restored for backward compatibility.
+  </description>
+</entry>


### PR DESCRIPTION
pr_rerun fix/2380_insufficient_args_in_ParameterFormatter to 2.x