### PR TITLE
Fix issue #2363: Extract Throwable should be irrelevant to the count of patternAnalysis

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
@@ -17,6 +17,8 @@
 package org.apache.logging.log4j.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -157,6 +159,17 @@ class ParameterizedMessageTest {
         param.set("000");
         final String after = msg.getFormattedMessage();
         assertThat(after).isEqualTo("Test message XYZ").as("Should not change after rendered once");
+    }
+
+    @Test
+    public void testException() {
+        final String testMsg = "Test message {}, exception is {}";
+        final ParameterizedMessage msg = new ParameterizedMessage(testMsg, "Apache", new NullPointerException());
+        final String result = msg.getFormattedMessage();
+        final String expected = "Test message Apache, exception is ";
+        assertThat(result).contains(expected);
+        final Throwable t = msg.getThrowable();
+        assertNotNull(t, "No Throwable");
     }
 
     static Stream<Object> testSerializable() {

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.math.BigDecimal;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -144,11 +144,10 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
         this.args = args;
         this.pattern = pattern;
         this.patternAnalysis = analyzePattern(pattern, args != null ? args.length : 0);
-        this.throwable = determineThrowable(throwable, this.args, patternAnalysis);
+        this.throwable = determineThrowable(throwable, this.args);
     }
 
-    private static Throwable determineThrowable(
-            final Throwable throwable, final Object[] args, final MessagePatternAnalysis analysis) {
+    private static Throwable determineThrowable(final Throwable throwable, final Object[] args) {
 
         // Short-circuit if an explicit `Throwable` is provided
         if (throwable != null) {
@@ -156,7 +155,8 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
         }
 
         // If the last `Throwable` argument is not consumed in the pattern, use that
-        if (args != null && args.length > analysis.placeholderCount) {
+        // Fix issue #2363: Extract Throwable should be irrelevant to the count of patternAnalysis
+        if (args != null && args.length > 0) {
             Object lastArg = args[args.length - 1];
             if (lastArg instanceof Throwable) {
                 return (Throwable) lastArg;


### PR DESCRIPTION
pr_rerun issue2363_fix_ParameterizedMessage_throwable to 2.x