### PR TITLE
Bump org.apache.commons:commons-dbcp2 from 2.9.0 to 2.11.0

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -73,7 +73,7 @@
     <commons-codec.version>1.16.0</commons-codec.version>
     <commons-compress.version>1.25.0</commons-compress.version>
     <commons-csv.version>1.10.0</commons-csv.version>
-    <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
+    <commons-dbcp2.version>2.11.0</commons-dbcp2.version>
     <commons-io.version>2.15.1</commons-io.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <commons-logging.version>1.3.0</commons-logging.version>


### PR DESCRIPTION
pr_rerun dependabot/maven/2.x/org.apache.commons-commons-dbcp2-2.11.0 to 2.x