### PR TITLE
Don't fail on insufficient parameters in `ParameterFormatter` (#2337)

### DIFF
--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/UsingStatusLoggerMock.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/UsingStatusLoggerMock.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 /**
  * Shortcut to {@link StatusLoggerMockExtension}.
@@ -32,4 +33,5 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target({TYPE, METHOD})
 @Documented
 @ExtendWith({ExtensionContextAnchor.class, StatusLoggerMockExtension.class})
+@ResourceLock("log4j2.StatusLogger")
 public @interface UsingStatusLoggerMock {}

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/package-info.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the license.
  */
 @Export
-@Version("2.23.0")
+@Version("2.23.1")
 package org.apache.logging.log4j.test.junit;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
@@ -17,21 +17,27 @@
 package org.apache.logging.log4j.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.logging.log4j.message.ParameterFormatter.MessagePatternAnalysis;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.test.junit.UsingStatusLoggerMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Tests {@link ParameterFormatter}.
  */
-public class ParameterFormatterTest {
+@UsingStatusLoggerMock
+class ParameterFormatterTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -49,7 +55,7 @@ public class ParameterFormatterTest {
         "4,0:2:4:10,false,{}{}{}a{]b{}",
         "5,0:2:4:7:10,false,{}{}{}a{}b{}"
     })
-    public void test_pattern_analysis(
+    void test_pattern_analysis(
             final int placeholderCount,
             final String placeholderCharIndicesString,
             final boolean escapedPlaceholderFound,
@@ -66,8 +72,23 @@ public class ParameterFormatterTest {
     }
 
     @ParameterizedTest
+    @CsvSource({"1,foo {}", "2,bar {}{}"})
+    void insufficient_args_should_not_throw_an_exception(final int placeholderCount, final String pattern) {
+        final int argCount = placeholderCount - 1;
+        final String formattedPattern = ParameterFormatter.format(pattern, new Object[argCount], argCount);
+        assertThat(formattedPattern).isEqualTo(pattern);
+        final ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(StatusLogger.getLogger()).error(eq("parameter formatting failure"), errorCaptor.capture());
+        final Throwable error = errorCaptor.getValue();
+        assertThat(error)
+                .hasMessage(
+                        "found %d argument placeholders, but provided %d for pattern `%s`",
+                        placeholderCount, argCount, pattern);
+    }
+
+    @ParameterizedTest
     @MethodSource("messageFormattingTestCases")
-    void assertMessageFormatting(
+    void test_message_formatting(
             final String pattern, final Object[] args, final int argCount, final String expectedFormattedMessage) {
         MessagePatternAnalysis analysis = ParameterFormatter.analyzePattern(pattern, -1);
         final StringBuilder buffer = new StringBuilder();

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
@@ -17,19 +17,26 @@
 package org.apache.logging.log4j.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.test.junit.Mutable;
 import org.apache.logging.log4j.test.junit.SerialUtil;
+import org.apache.logging.log4j.test.junit.UsingStatusLoggerMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
-public class ParameterizedMessageTest {
+@UsingStatusLoggerMock
+class ParameterizedMessageTest {
 
     @Test
-    public void testNoArgs() {
+    void testNoArgs() {
         final String testMsg = "Test message {}";
         ParameterizedMessage msg = new ParameterizedMessage(testMsg, (Object[]) null);
         String result = msg.getFormattedMessage();
@@ -41,7 +48,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testZeroLength() {
+    void testZeroLength() {
         final String testMsg = "";
         ParameterizedMessage msg = new ParameterizedMessage(testMsg, new Object[] {"arg"});
         String result = msg.getFormattedMessage();
@@ -53,7 +60,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testOneCharLength() {
+    void testOneCharLength() {
         final String testMsg = "d";
         ParameterizedMessage msg = new ParameterizedMessage(testMsg, new Object[] {"arg"});
         String result = msg.getFormattedMessage();
@@ -65,7 +72,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testFormat3StringArgs() {
+    void testFormat3StringArgs() {
         final String testMsg = "Test message {}{} {}";
         final String[] args = {"a", "b", "c"};
         final String result = ParameterizedMessage.format(testMsg, args);
@@ -73,7 +80,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testFormatNullArgs() {
+    void testFormatNullArgs() {
         final String testMsg = "Test message {} {} {} {} {} {}";
         final String[] args = {"a", null, "c", null, null, null};
         final String result = ParameterizedMessage.format(testMsg, args);
@@ -81,7 +88,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testFormatStringArgsIgnoresSuperfluousArgs() {
+    void testFormatStringArgsIgnoresSuperfluousArgs() {
         final String testMsg = "Test message {}{} {}";
         final String[] args = {"a", "b", "c", "unnecessary", "superfluous"};
         final String result = ParameterizedMessage.format(testMsg, args);
@@ -89,7 +96,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testFormatStringArgsWithEscape() {
+    void testFormatStringArgsWithEscape() {
         final String testMsg = "Test message \\{}{} {}";
         final String[] args = {"a", "b", "c"};
         final String result = ParameterizedMessage.format(testMsg, args);
@@ -97,7 +104,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testFormatStringArgsWithTrailingEscape() {
+    void testFormatStringArgsWithTrailingEscape() {
         final String testMsg = "Test message {}{} {}\\";
         final String[] args = {"a", "b", "c"};
         final String result = ParameterizedMessage.format(testMsg, args);
@@ -105,7 +112,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testFormatStringArgsWithTrailingText() {
+    void testFormatStringArgsWithTrailingText() {
         final String testMsg = "Test message {}{} {}Text";
         final String[] args = {"a", "b", "c"};
         final String result = ParameterizedMessage.format(testMsg, args);
@@ -113,7 +120,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testFormatStringArgsWithTrailingEscapedEscape() {
+    void testFormatStringArgsWithTrailingEscapedEscape() {
         final String testMsg = "Test message {}{} {}\\\\";
         final String[] args = {"a", "b", "c"};
         final String result = ParameterizedMessage.format(testMsg, args);
@@ -121,7 +128,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testFormatStringArgsWithEscapedEscape() {
+    void testFormatStringArgsWithEscapedEscape() {
         final String testMsg = "Test message \\\\{}{} {}";
         final String[] args = {"a", "b", "c"};
         final String result = ParameterizedMessage.format(testMsg, args);
@@ -129,7 +136,7 @@ public class ParameterizedMessageTest {
     }
 
     @Test
-    public void testSafeWithMutableParams() { // LOG4J2-763
+    void testSafeWithMutableParams() { // LOG4J2-763
         final String testMsg = "Test message {}";
         final Mutable param = new Mutable().set("abc");
         final ParameterizedMessage msg = new ParameterizedMessage(testMsg, param);
@@ -169,5 +176,50 @@ public class ParameterizedMessageTest {
         final Message actual = SerialUtil.deserialize(SerialUtil.serialize(expected));
         assertThat(actual).isInstanceOf(ParameterizedMessage.class);
         assertThat(actual.getFormattedMessage()).isEqualTo(expected.getFormattedMessage());
+    }
+
+    static Stream<Object[]> testCasesForInsufficientFormatArgs() {
+        return Stream.of(new Object[] {1, "foo {}"}, new Object[] {2, "bar {}{}"});
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCasesForInsufficientFormatArgs")
+    void formatTo_should_fail_on_insufficient_args(final int placeholderCount, final String pattern) {
+        final int argCount = placeholderCount - 1;
+        verifyFormattingFailureOnInsufficientArgs(placeholderCount, pattern, argCount, () -> {
+            final ParameterizedMessage message = new ParameterizedMessage(pattern, new Object[argCount]);
+            final StringBuilder buffer = new StringBuilder();
+            message.formatTo(buffer);
+            return buffer.toString();
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCasesForInsufficientFormatArgs")
+    void format_should_fail_on_insufficient_args(final int placeholderCount, final String pattern) {
+        final int argCount = placeholderCount - 1;
+        verifyFormattingFailureOnInsufficientArgs(
+                placeholderCount, pattern, argCount, () -> ParameterizedMessage.format(pattern, new Object[argCount]));
+    }
+
+    private static void verifyFormattingFailureOnInsufficientArgs(
+            final int placeholderCount,
+            final String pattern,
+            final int argCount,
+            final Supplier<String> formattedMessageSupplier) {
+
+        // Verify the formatted message
+        final String formattedMessage = formattedMessageSupplier.get();
+        assertThat(formattedMessage).isEqualTo(pattern);
+
+        // Verify the logged failure
+        final ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(StatusLogger.getLogger()).error(eq("message formatting failure"), errorCaptor.capture());
+        final Throwable error = errorCaptor.getValue();
+        assertThat(error)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "found %d argument placeholders, but provided %d for pattern `%s`",
+                        placeholderCount, argCount, pattern);
     }
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
@@ -224,7 +224,7 @@ class ParameterizedMessageTest {
         assertThat(statusDataList).hasSize(1);
         final StatusData statusData = statusDataList.get(0);
         assertThat(statusData.getLevel()).isEqualTo(Level.ERROR);
-        assertThat(statusData.getMessage().getFormattedMessage()).isEqualTo("message formatting failure");
+        assertThat(statusData.getMessage().getFormattedMessage()).isEqualTo("Unable to format msg: %s", pattern);
         assertThat(statusData.getThrowable())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -26,8 +26,6 @@ import java.util.Date;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.StringBuilders;
 
 /**
@@ -63,8 +61,6 @@ final class ParameterFormatter {
     private static final char DELIM_START = '{';
     private static final char DELIM_STOP = '}';
     private static final char ESCAPE_CHAR = '\\';
-
-    private static final Logger STATUS_LOGGER = StatusLogger.getLogger();
 
     private static final DateTimeFormatter DATE_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
@@ -209,11 +205,12 @@ final class ParameterFormatter {
     }
 
     /**
-     * Format the following pattern using provided arguments.
+     * Format the given pattern using provided arguments.
      *
      * @param pattern a formatting pattern
      * @param args arguments to be formatted
      * @return the formatted message
+     * @throws IllegalArgumentException on invalid input
      */
     static String format(final String pattern, final Object[] args, int argCount) {
         final StringBuilder result = new StringBuilder();
@@ -222,6 +219,14 @@ final class ParameterFormatter {
         return result.toString();
     }
 
+    /**
+     * Format the given pattern using provided arguments into the buffer pointed.
+     *
+     * @param buffer a buffer the formatted output will be written to
+     * @param pattern a formatting pattern
+     * @param args arguments to be formatted
+     * @throws IllegalArgumentException on invalid input
+     */
     static void formatMessage(
             final StringBuilder buffer,
             final String pattern,
@@ -240,10 +245,7 @@ final class ParameterFormatter {
             final String message = String.format(
                     "found %d argument placeholders, but provided %d for pattern `%s`",
                     analysis.placeholderCount, args.length, pattern);
-            final Throwable error = new IllegalArgumentException(message);
-            STATUS_LOGGER.error("parameter formatting failure", error);
-            buffer.append(pattern);
-            return;
+            throw new IllegalArgumentException(message);
         }
 
         // Fast-path for patterns containing no escapes

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -281,7 +281,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
             try {
                 ParameterFormatter.formatMessage(buffer, pattern, args, argCount, patternAnalysis);
             } catch (final Exception error) {
-                STATUS_LOGGER.error("message formatting failure", error);
+                STATUS_LOGGER.error("Unable to format msg: {}", pattern, error);
                 buffer.append(pattern);
             }
         }
@@ -297,7 +297,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
         try {
             return ParameterFormatter.format(pattern, args, argCount);
         } catch (final Exception error) {
-            STATUS_LOGGER.error("message formatting failure", error);
+            STATUS_LOGGER.error("Unable to format msg: {}", pattern, error);
             return pattern;
         }
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -26,7 +26,9 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterFormatter.MessagePatternAnalysis;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.internal.SerializationUtil;
@@ -78,6 +80,8 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     public static final String ERROR_SUFFIX = ParameterFormatter.ERROR_SUFFIX;
 
     private static final long serialVersionUID = -665975803997290697L;
+
+    private static final Logger STATUS_LOGGER = StatusLogger.getLogger();
 
     private static final ThreadLocal<FormatBufferHolder> FORMAT_BUFFER_HOLDER_REF =
             Constants.ENABLE_THREADLOCALS ? ThreadLocal.withInitial(FormatBufferHolder::new) : null;
@@ -274,7 +278,12 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
             buffer.append(formattedMessage);
         } else {
             final int argCount = args != null ? args.length : 0;
-            ParameterFormatter.formatMessage(buffer, pattern, args, argCount, patternAnalysis);
+            try {
+                ParameterFormatter.formatMessage(buffer, pattern, args, argCount, patternAnalysis);
+            } catch (final Exception error) {
+                STATUS_LOGGER.error("message formatting failure", error);
+                buffer.append(pattern);
+            }
         }
     }
 
@@ -285,7 +294,12 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      */
     public static String format(final String pattern, final Object[] args) {
         final int argCount = args != null ? args.length : 0;
-        return ParameterFormatter.format(pattern, args, argCount);
+        try {
+            return ParameterFormatter.format(pattern, args, argCount);
+        } catch (final Exception error) {
+            STATUS_LOGGER.error("message formatting failure", error);
+            return pattern;
+        }
     }
 
     @Override

--- a/src/changelog/.2.x.x/fix_ParameterFormatter_for_insufficient_args.xml
+++ b/src/changelog/.2.x.x/fix_ParameterFormatter_for_insufficient_args.xml
@@ -3,5 +3,6 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
        type="fixed">
+  <issue id="2343" link="https://github.com/apache/logging-log4j2/pull/2343"/>
   <description format="asciidoc">Fix that parameterized message formatting doesn't throw an exception when there are insufficient number of parameters</description>
 </entry>

--- a/src/changelog/.2.x.x/fix_ParameterFormatter_for_insufficient_args.xml
+++ b/src/changelog/.2.x.x/fix_ParameterFormatter_for_insufficient_args.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <description format="asciidoc">Fix that parameterized message formatting doesn't throw an exception when there are insufficient number of parameters</description>
+</entry>


### PR DESCRIPTION
pr_rerun 2.x-ParameterFormatter-insufficient-args to 2.x