### PR TITLE
Bump org.springframework:spring-core from 5.3.31 to 6.0.15 in /log4j-parent

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -139,7 +139,7 @@
     <plexus-utils.version>3.5.1</plexus-utils.version>
     <slf4j.version>2.0.9</slf4j.version>
     <spring-boot.version>2.7.18</spring-boot.version>
-    <spring-framework.version>5.3.31</spring-framework.version>
+    <spring-framework.version>6.0.15</spring-framework.version>
     <system-stubs.version>2.0.3</system-stubs.version>
     <tomcat-juli.version>10.0.27</tomcat-juli.version>
     <velocity.version>1.7</velocity.version>


### PR DESCRIPTION
pr_rerun dependabot/maven/log4j-parent/org.springframework-spring-core-6.0.15 to 2.x